### PR TITLE
Fixed "The [database] option does not exist." exception for "migrate-…

### DIFF
--- a/src/Console/Commands/RollbackDataCommand.php
+++ b/src/Console/Commands/RollbackDataCommand.php
@@ -27,7 +27,7 @@ class RollbackDataCommand extends RollbackCommand
      *
      * @var string
      */
-    protected $signature = 'migrate-data:rollback';
+    protected $name = 'migrate-data:rollback';
 
     /**
      * The console command description.


### PR DESCRIPTION
As you extend \Illuminate\Database\Console\Migrations\RollbackCommand you should override $name property, but you did override $signature.