### PR TITLE
add missing --graceful option

### DIFF
--- a/src/Console/Commands/MigrateDataCommand.php
+++ b/src/Console/Commands/MigrateDataCommand.php
@@ -33,7 +33,8 @@ class MigrateDataCommand extends MigrateCommand
                 {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
                 {--pretend : Dump the SQL queries that would be run}
                 {--seed : Indicates if the seed task should be re-run}
-                {--step : Force the migrations to be run so they can be rolled back individually}';
+                {--step : Force the migrations to be run so they can be rolled back individually}
+                {--graceful : Return a successful exit code even if an error occurs}';
 
     /**
      * The console command description.


### PR DESCRIPTION
On newer Laravel versions, the built-in `MigrateCommand` comes with an extra option:

```
{--graceful : Return a successful exit code even if an error occurs}
```

This will cause `php artisan migrate-data` to fail with `The "graceful" option does not exist.`.

This PR will fix that.